### PR TITLE
🩹📝 fix docs PDF build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,7 @@ latex_elements = {
     "releasename": "Version",
     "printindex": r"\footnotesize\raggedright\printindex",
     "tableofcontents": "",
+    "sphinxsetup": "iconpackage=fontawesome",
     "extrapackages": r"\usepackage{qrcode,graphicx,calc,amsthm,etoolbox,flushend}",
     "preamble": r"""
 \patchcmd{\thebibliography}{\addcontentsline{toc}{section}{\refname}}{}{}{}


### PR DESCRIPTION
This small PR fixes the PDF docs build to get the RtD build working again on releases. A similar fix has already been deployed in mqt-core and is working over there.