### PR TITLE
📝 Add MQT citation information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,151 @@
+cff-version: 1.2.0
+title: Munich Quantum Toolkit (MQT)
+message: >-
+  Please cite the MQT using the metadata from 'preferred-citation'.
+type: software
+authors:
+  - given-names: Robert
+    family-names: Wille
+    email: robert.wille@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0002-4993-7860'
+  - given-names: Lucas
+    family-names: Berent
+    email: lucas.berent@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0002-2973-1689'
+  - given-names: Tobias
+    family-names: Forster
+    email: tobias.forster@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0009-0009-5900-7438'
+  - given-names: Jagatheesan
+    family-names: Kunasaikaran
+    email: jagatheesan.kunasaikaran@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0009-0003-7097-5428'
+  - given-names: Kevin
+    family-names: Mato
+    email: kevin.mato@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0003-2073-5226'
+  - given-names: Tom
+    family-names: Peham
+    email: tom.peham@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0003-3434-7881'
+  - given-names: Nils
+    family-names: Quetschlich
+    email: nils.quetschlich@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0002-4369-5207'
+  - given-names: Damian
+    family-names: Rovara
+    email: damian.rovara@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0009-0000-7416-9149'
+  - given-names: Aaron
+    family-names: Sander
+    email: aaron.sander@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0009-0007-9166-6113'
+  - given-names: Ludwig
+    family-names: Schmid
+    email: ludwig.s.schmid@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0002-4246-8125'
+  - given-names: Daniel
+    family-names: Schoenberger
+    email: daniel.schoenberger@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0009-0005-8059-0534'
+  - given-names: Yannick
+    family-names: Stade
+    email: yannick.stade@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0001-5785-2528'
+  - given-names: Lukas
+    family-names: Burgholzer
+    email: lukas.burgholzer@tum.de
+    affiliation: 'Technical University of Munich, Germany'
+    orcid: 'https://orcid.org/0000-0003-4699-1316'
+identifiers:
+  - type: doi
+    value: 10.1109/QSW62656.2024.00013
+  - type: url
+    value: 'https://arxiv.org/abs/2405.17543'
+url: 'https://mqt.readthedocs.io'
+license: MIT
+preferred-citation:
+    type: conference-paper
+    title: "The MQT Handbook: A Summary of Design Automation Tools and Software for Quantum Computing"
+    conference: "IEEE International Conference on Quantum Software (QSW)"
+    year: 2024
+    month: 7
+    doi: "10.1109/QSW62656.2024.00013"
+    authors:
+      - given-names: Robert
+        family-names: Wille
+        email: robert.wille@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0002-4993-7860'
+      - given-names: Lucas
+        family-names: Berent
+        email: lucas.berent@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0002-2973-1689'
+      - given-names: Tobias
+        family-names: Forster
+        email: tobias.forster@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0009-0009-5900-7438'
+      - given-names: Jagatheesan
+        family-names: Kunasaikaran
+        email: jagatheesan.kunasaikaran@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0009-0003-7097-5428'
+      - given-names: Kevin
+        family-names: Mato
+        email: kevin.mato@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0003-2073-5226'
+      - given-names: Tom
+        family-names: Peham
+        email: tom.peham@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0003-3434-7881'
+      - given-names: Nils
+        family-names: Quetschlich
+        email: nils.quetschlich@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0002-4369-5207'
+      - given-names: Damian
+        family-names: Rovara
+        email: damian.rovara@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0009-0000-7416-9149'
+      - given-names: Aaron
+        family-names: Sander
+        email: aaron.sander@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0009-0007-9166-6113'
+      - given-names: Ludwig
+        family-names: Schmid
+        email: ludwig.s.schmid@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0002-4246-8125'
+      - given-names: Daniel
+        family-names: Schoenberger
+        email: daniel.schoenberger@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0009-0005-8059-0534'
+      - given-names: Yannick
+        family-names: Stade
+        email: yannick.stade@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0001-5785-2528'
+      - given-names: Lukas
+        family-names: Burgholzer
+        email: lukas.burgholzer@tum.de
+        affiliation: 'Technical University of Munich, Germany'
+        orcid: 'https://orcid.org/0000-0003-4699-1316'

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ The [_Munich Quantum Toolkit (MQT)_](https://mqt.readthedocs.io) is a collection
   </a>
 </p>
 
+If you want to cite the Munich Quantum Toolkit, please use the following BibTeX entry:
+
+```bibtex
+@inproceedings{mqt,
+    title = {The {{MQT}} Handbook: {{A}} Summary of Design Automation Tools and Software for Quantum Computing},
+    shorttitle = {{The MQT Handbook}},
+    booktitle = {IEEE International Conference on Quantum Software (QSW)},
+    author = {Wille, Robert and Berent, Lucas and Forster, Tobias and Kunasaikaran, Jagatheesan and Mato, Kevin and Peham, Tom and Quetschlich, Nils and Rovara, Damian and Sander, Aaron and Schmid, Ludwig and Schoenberger, Daniel and Stade, Yannick and Burgholzer, Lukas},
+    date = {2024},
+    doi = {10.1109/QSW62656.2024.00013},
+    eprint  = {2405.17543},
+    eprinttype = {arxiv},
+    addendum = {A live version of this document is available at \url{https://mqt.readthedocs.io}},
+}
+```
+
 <!-- SPHINX-START -->
 
 ## GitHub Information

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -36,7 +36,8 @@ body:not([data-theme="light"]) .highlight .sa,
 .highlight .sr,
 .highlight .s1,
 .highlight .ss,
-.highlight .s1 {
+.highlight .s1,
+.highlight .s {
   background-color: #00000001;
 }
 
@@ -46,4 +47,8 @@ body:not([data-theme="light"]) {
   --mystnb-stdout-bg-color: #1a1c1e;
   --mystnb-stderr-bg-color: #442222;
   --mystnb-traceback-bg-color: #202020;
+}
+
+body:not([data-theme="light"]) .highlight .gp {
+  color: #c65d09;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,23 @@ A live version of this document is available at [mqt.readthedocs.io](https://mqt
 \sphinxtableofcontents
 ```
 
-```{only} html
+````{only} html
+If you want to cite the Munich Quantum Toolkit, please use the following BibTeX entry:
+
+```bibtex
+@inproceedings{mqt,
+    title = {The {{MQT}} Handbook: {{A}} Summary of Design Automation Tools and Software for Quantum Computing},
+    shorttitle = {{The MQT Handbook}},
+    booktitle = {IEEE International Conference on Quantum Software (QSW)},
+    author = {Wille, Robert and Berent, Lucas and Forster, Tobias and Kunasaikaran, Jagatheesan and Mato, Kevin and Peham, Tom and Quetschlich, Nils and Rovara, Damian and Sander, Aaron and Schmid, Ludwig and Schoenberger, Daniel and Stade, Yannick and Burgholzer, Lukas},
+    date = {2024},
+    doi = {10.1109/QSW62656.2024.00013},
+    eprint  = {2405.17543},
+    eprinttype = {arxiv},
+    addendum = {A live version of this document is available at \url{https://mqt.readthedocs.io}},
+}
+```
+
 For a comprehensive visual depiction of the MQT tools, we invite you to download our <a href="_static/flyers/mqt_flyer.pdf" title="Link to MQT flyer">MQT Flyer</a>.
 
 <div style="float: right; margin-top:0em; margin-bottom:3em;">
@@ -46,7 +62,7 @@ For a comprehensive visual depiction of the MQT tools, we invite you to download
         </figure>
     </a>
 </div>
-```
+````
 
 ```{toctree}
 :caption: The MQT Handbook


### PR DESCRIPTION
This PR adds appropriate citation information for the MQT to the readme and the RtD docs. In addition, it adds a `CITATION.cff` file, which should be automatically picked up by GitHub.